### PR TITLE
Fix: Unicode lower-casing does not preserve length

### DIFF
--- a/src/error_align/utils.py
+++ b/src/error_align/utils.py
@@ -1,9 +1,13 @@
+import unicodedata
 from dataclasses import dataclass
 from enum import IntEnum
 from itertools import chain, combinations
 
 import regex as re
 from unidecode import unidecode
+
+# Build a translation table that maps all Mn (non-spacing mark) code points to None
+_MN_TABLE = str.maketrans({cp: None for cp in range(0x110000) if unicodedata.category(chr(cp)) == "Mn"})
 
 
 class OpType(IntEnum):
@@ -152,7 +156,7 @@ def basic_normalizer(text: str) -> str:
         str: The normalized text.
 
     """
-    return text.lower()
+    return text.lower().translate(_MN_TABLE)
 
 
 def ensure_length_preservation(normalizer: callable) -> callable:

--- a/src/error_align/utils.py
+++ b/src/error_align/utils.py
@@ -1,13 +1,9 @@
-import unicodedata
 from dataclasses import dataclass
 from enum import IntEnum
 from itertools import chain, combinations
 
 import regex as re
 from unidecode import unidecode
-
-# Build a translation table that maps all Mn (non-spacing mark) code points to None
-_MN_TABLE = str.maketrans({cp: None for cp in range(0x110000) if unicodedata.category(chr(cp)) == "Mn"})
 
 
 class OpType(IntEnum):
@@ -153,7 +149,11 @@ def basic_tokenizer(text: str) -> list:
 
 
 def basic_normalizer(text: str) -> str:
-    """Default normalizer that only converts text to lowercase.
+    """Default normalizer that converts text to lowercase.
+
+    U+0130 (İ, Latin capital letter I with dot above) is replaced with a plain
+    'I' before lowercasing to prevent the length-expanding decomposition that
+    Python's str.lower() would otherwise produce ('i' + combining dot above).
 
     Args:
         text (str): The input text to normalize.
@@ -162,7 +162,7 @@ def basic_normalizer(text: str) -> str:
         str: The normalized text.
 
     """
-    return text.lower().translate(_MN_TABLE)
+    return text.replace("\u0130", "I").lower()
 
 
 def ensure_length_preservation(normalizer: callable) -> callable:

--- a/src/error_align/utils.py
+++ b/src/error_align/utils.py
@@ -97,7 +97,10 @@ def is_vowel(c: str) -> bool:
 
     """
     assert len(c) == 1, "Input must be a single character."
-    return unidecode(c)[0] in "aeiouy"
+    decode_char = unidecode(c)
+    if len(decode_char) == 0:
+        return False
+    return decode_char[0] in "aeiouy"
 
 
 def is_consonant(c: str) -> bool:
@@ -111,7 +114,10 @@ def is_consonant(c: str) -> bool:
 
     """
     assert len(c) == 1, "Input must be a single character."
-    return unidecode(c)[0] in "bcdfghjklmnpqrstvwxyz"
+    decode_char = unidecode(c)
+    if len(decode_char) == 0:
+        return False
+    return decode_char[0] in "bcdfghjklmnpqrstvwxyz"
 
 
 def categorize_char(c: str) -> int:

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -8,7 +8,7 @@ from error_align.beam_search import error_align_beam_search as python_error_alig
 from error_align.edit_distance import compute_error_align_distance_matrix, compute_levenshtein_distance_matrix
 from error_align.error_align import prepare_graph_metadata
 from error_align.graph_metadata import SubgraphMetadata
-from error_align.utils import Alignment, OpType, categorize_char, ensure_length_preservation
+from error_align.utils import Alignment, OpType, basic_normalizer, categorize_char, ensure_length_preservation
 
 
 def test_error_align() -> None:
@@ -232,3 +232,10 @@ def test_normalization_guardrails() -> None:
         raise AssertionError("Expected ValueError for length mismatch.")
     except ValueError:
         pass
+
+
+def test_basic_normalizer_dotted_capital_i() -> None:
+    """Regression test: U+0130 (İ) must not expand length when lowercased."""
+    result = basic_normalizer("İstanbul")
+    assert result == "istanbul"
+    assert len(result) == len("İstanbul")

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -8,7 +8,15 @@ from error_align.beam_search import error_align_beam_search as python_error_alig
 from error_align.edit_distance import compute_error_align_distance_matrix, compute_levenshtein_distance_matrix
 from error_align.error_align import prepare_graph_metadata
 from error_align.graph_metadata import SubgraphMetadata
-from error_align.utils import Alignment, OpType, basic_normalizer, categorize_char, ensure_length_preservation
+from error_align.utils import (
+    Alignment,
+    OpType,
+    basic_normalizer,
+    categorize_char,
+    ensure_length_preservation,
+    is_consonant,
+    is_vowel,
+)
 
 
 def test_error_align() -> None:
@@ -232,6 +240,13 @@ def test_normalization_guardrails() -> None:
         raise AssertionError("Expected ValueError for length mismatch.")
     except ValueError:
         pass
+
+
+def test_is_vowel_and_is_consonant_with_empty_unidecode() -> None:
+    """Regression test: characters that unidecode to '' must return False instead of crashing."""
+    # U+0300 (combining grave accent) unidecodes to an empty string
+    assert is_vowel("\u0300") is False
+    assert is_consonant("\u0300") is False
 
 
 def test_basic_normalizer_dotted_capital_i() -> None:


### PR DESCRIPTION
## Description
- Replace expanding character `İ` with `I` before lowercasing.
- Implement fail safe when characters converted with `unidecode` translate to the empty string.

<!--
Do not leave this blank.
This PR [adds/removes/fixes/replaces] the [feature/bug/etc] because [reason] by doing [x].
-->

<!--
Before submitting a Pull Request, please ensure you've done the following:
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes (if required).
- 📗 Update any related documentation (if required).
-->
